### PR TITLE
Fix import path and wifi config check

### DIFF
--- a/selfhelperscripts/__init__.py
+++ b/selfhelperscripts/__init__.py
@@ -1,1 +1,5 @@
-from src.cmd_helper.cmd_helper import CmdHelper
+"""Convenience imports for the package."""
+
+from selfhelperscripts.src.cmd_helper.cmd_helper import CmdHelper
+
+__all__ = ["CmdHelper"]

--- a/selfhelperscripts/scripts/connect_wifi.sh
+++ b/selfhelperscripts/scripts/connect_wifi.sh
@@ -20,8 +20,8 @@ if [ -z "$SSID" ]; then
   exit 1
 fi
 
-if [ -z "$WIFI_PASSWORD" ]; then
-  echo "❌ SSID не указан в конфиге!"
+if [ -z "${WIFI_PASSWORD+x}" ]; then
+  echo "❌ WIFI_PASSWORD не указан в конфиге!"
   exit 1
 fi
 echo "Отключаем от текущей Wi-Fi сети..."

--- a/setup.py
+++ b/setup.py
@@ -8,8 +8,7 @@ setup(
     long_description=open("README.md", "r", encoding="utf-8").read(),
     long_description_content_type="text/markdown",
     url="https://github.com/mshegole/selfhelpscripts",
-    package_dir={'': 'selfhelperscripts/src'},
-    packages=find_packages(where='src'),
+    packages=find_packages(),
     classifiers=[
         "Programming Language :: Python :: 3",
         "Programming Language :: Python :: 3.10",


### PR DESCRIPTION
## Summary
- fix incorrect import path in `__init__`
- fix missing package discovery
- fix WiFi script to handle empty password variable

## Testing
- `python3 -m isort selfhelperscripts/src`
- `python3 -m black --config=project.toml selfhelperscripts/src`
- `python3 -m flake8 --config=setup.cfg`
- `python3 -m mypy --config=setup.cfg selfhelperscripts/src`
- `bash selfhelperscripts/scripts/tnow.sh`


------
https://chatgpt.com/codex/tasks/task_e_68417581d3ec832da0449a16ed3ef63f